### PR TITLE
feat: dump soratun configuration as WireGuard conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # soratun
 
-An easy-to-use, userspace [SORACOM Arc](https://soracom.jp/services/arc/) client powered by [wireguard-go](https://git.zx2c4.com/wireguard-go/about/). For deploying and scaling Raspberry Pi devices working with SORACOM platform and SORACOM Arc.
+An easy-to-use, userspace [SORACOM Arc](https://soracom.jp/services/arc/) client powered by [wireguard-go](https://git.zx2c4.com/wireguard-go/about/). For deploying and scaling Linux servers/Raspberry Pi devices working with SORACOM platform and SORACOM Arc.
 
 - Quick deployment (copy one or two binary files and done)
 - Integration with SORACOM platform
 
 ## Tested Platforms
 
-- Ubuntu 20.04.02 LTS on amd64
-- Ubuntu 20.04.02 LTS on arm
-  - Raspberry Pi 4 Model B (4 GB) (Linux ubuntu 5.4.0-1034-raspi #37-Ubuntu SMP PREEMPT Mon Apr 12 23:18:42 UTC 2021 armv7l armv7l armv7l GNU/Linux)
+- Linux amd64
+  - Ubuntu 20.04.2 LTS
+- Linux arm (Raspberry Pi 32-bit)
+  - Raspberry Pi OS 2021-05-07
+  - Ubuntu 20.04.2 LTS
 - macOS Big Sur 11.3 (20E232) -- **For development and testing purpose only**
 
 ## Usage
@@ -36,7 +38,7 @@ Flags:
 Use "soratun [command] --help" for more information about a command.
 ```
 
-See the schema ([English](./docs/config.en.md) / [Japanese](./docs/config.ja.md)) for configuration file `arc.json` format.
+See the schema ([English](./docs/config.en.md) / [Japanese](./docs/config.ja.md)) for configuration file `arc.json` detail.
 
 ### Getting Started
 
@@ -90,7 +92,7 @@ See the schema ([English](./docs/config.en.md) / [Japanese](./docs/config.ja.md)
 Tips: you can skip interactive wizard by supplying required parameters via flags as follows.
 
 ```console
-./soratun bootstrap authkey --auth-key-id keyId-xxx --auth-key secret-xxx --coverage-type jp
+$ soratun bootstrap authkey --auth-key-id keyId-xxx --auth-key secret-xxx --coverage-type jp
 ```
 
 For other bootstrapping method detail, please consult SORACOM documentation at:
@@ -103,11 +105,11 @@ For other bootstrapping method detail, please consult SORACOM documentation at:
 Use [`conf/soratun.service.sample`](conf/soratun.service.sample) as a starter, copy file you edited to `/etc/systemd/system/soratun.service` directory, then
 
 ```console
-# sudo systemctl enable soratun
-# sudo systemctl start soratun
-# sudo systemctl status soratun
-# journalctl -u soratun -f
-# sudo systemctl stop soratun
+$ sudo systemctl enable soratun
+$ sudo systemctl start soratun
+$ sudo systemctl status soratun
+$ journalctl -u soratun -f
+$ sudo systemctl stop soratun
 ```
 
 `soratun` supports systemd watchdog. It'll update the timer every 110 seconds, based on [Protocol & Cryptography - WireGuard](https://www.wireguard.com/protocol/):

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Available Commands:
   status      Display SORACOM Arc interface status
   up          Setup SORACOM Arc interface
   version     Show version
+  wg-config   Dump soratun configuration file as WireGuard format
 
 Flags:
       --config string   Specify path to SORACOM Arc client configuration file (default "arc.json")

--- a/cmd/dump_wireguard_config.go
+++ b/cmd/dump_wireguard_config.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"net"
+	"strings"
+)
+
+func dumpWireGuardConfigCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "wg-config",
+		Short:  "Dump soratun configuration file as WireGuard format",
+		PreRun: initSoratun,
+		Run: func(cmd *cobra.Command, args []string) {
+			dumpWireGuardConfig()
+		},
+	}
+}
+
+func dumpWireGuardConfig() {
+	var ips []string
+	for _, ip := range Config.ArcSession.ArcAllowedIPs {
+		ips = append(ips, (*net.IPNet)(ip).String())
+	}
+
+	fmt.Printf(`[Interface]
+Address = %s/32
+PrivateKey = %s
+MTU = %d
+
+[Peer]
+PublicKey = %s
+AllowedIPs = %s
+Endpoint = %s:%d
+PersistentKeepalive = %d
+`,
+		Config.ArcSession.ArcClientPeerIpAddress,
+		Config.PrivateKey,
+		Config.Mtu,
+		Config.ArcSession.ArcServerPeerPublicKey,
+		strings.Join(ips, ", "),
+		Config.ArcSession.ArcServerEndpoint.IP,
+		Config.ArcSession.ArcServerEndpoint.Port,
+		Config.PersistentKeepalive,
+	)
+}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/soracom/soratun"
 	"github.com/spf13/cobra"
 	"log"
@@ -18,12 +19,10 @@ func upCmd() *cobra.Command {
 				log.Fatal("Failed to determine connection information. Please bootstrap or create a new session from the user console.")
 			}
 
-			if len(Config.AdditionalAllowedIPs) > 0 {
-				Config.ArcSession.ArcAllowedIPs = append(Config.ArcSession.ArcAllowedIPs, Config.AdditionalAllowedIPs...)
-			}
-
 			if v := os.Getenv("SORACOM_VERBOSE"); v != "" {
-				dumpWireGuardConfig(Config.ArcSession)
+				fmt.Println("--- WireGuard configuration ----------------------")
+				dumpWireGuardConfig()
+				fmt.Println("--- End of WireGuard configuration ---------------")
 			}
 
 			soratun.Up(ctx, Config)


### PR DESCRIPTION
Sometime it's handy for users to convert current soratun configuration (`arc.conf`) to WireGuard configuration format. This PR will add new subcommand wg-config to do that.
