### PR TITLE
docs: update building instruction

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 ```console
 $ git clone https://github.com/soracom/soratun
 $ cd soratun
-$ make
+$ make soratun
 ```
 
 If you update configuration file (`arc.json`) format, please update relevant [JSON


### PR DESCRIPTION
After introducing CI and integration test insfrastructure (#5, f24e1cd95982f514575db61f9fc17d817635f3f9), the default target of the `Makefile` was updated. This PR reflects the update to the documentation. 
