### PR TITLE
Change it export the original (i.e. raw) Arc server endpoint to a configuration file

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,8 +30,9 @@ func configCmd() *cobra.Command {
 				ArcSession: &soratun.ArcSession{
 					ArcServerPeerPublicKey: soratun.Key{},
 					ArcServerEndpoint: &soratun.UDPAddr{
-						IP:   localhost,
-						Port: 11010,
+						IP:          localhost,
+						Port:        11010,
+						RawEndpoint: []byte("localhost:11010"),
 					},
 					ArcAllowedIPs: []*soratun.IPNet{{
 						IP:   net.IPv4(100, 127, 0, 0),

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/soracom/soratun"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_configCmd(t *testing.T) {
+	// preparing to capture stdout
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+
+	func() {
+		os.Stdout = w
+		defer func() {
+			_ = w.Close()
+			os.Stdout = originalStdout
+		}()
+
+		os.Args = []string{"__soratun__", "config"}
+		err := RootCmd.Execute()
+		assert.NoError(t, err)
+	}()
+
+	captured, err := io.ReadAll(r)
+	assert.NoError(t, err)
+
+	var conf soratun.Config
+	err = json.Unmarshal(captured, &conf)
+	assert.NoError(t, err)
+
+	localhost, err := net.LookupIP("localhost")
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, localhost[0], conf.ArcSession.ArcServerEndpoint.IP)
+	assert.Equal(t, 11010, conf.ArcSession.ArcServerEndpoint.Port)
+	assert.EqualValues(t, "localhost:11010", conf.ArcSession.ArcServerEndpoint.RawEndpoint)
+}

--- a/config.go
+++ b/config.go
@@ -12,12 +12,17 @@ import (
 
 const arcServerEndpointDefaultPort string = "11010"
 
+// UDPAddr represents the UDP address with keeping original endpoint.
+type UDPAddr struct {
+	IP          net.IP
+	Port        int
+	RawEndpoint []byte
+}
+
 // aliases to add custom un/marshaler to each types.
 type (
 	// Key is an alias for wgtypes.Key.
 	Key wgtypes.Key
-	// UDPAddr is an alias for net.UDPAddr.
-	UDPAddr net.UDPAddr
 	// IPNet is an alias for net.IPNet.
 	IPNet net.IPNet
 )
@@ -126,12 +131,16 @@ func (a *UDPAddr) UnmarshalText(text []byte) error {
 	}
 
 	a.IP, a.Port = ip, port
+	a.RawEndpoint = text
 	return nil
 }
 
 // MarshalText converts struct to a string.
 func (a *UDPAddr) MarshalText() ([]byte, error) {
-	return []byte(fmt.Sprintf("%s:%d", a.IP, a.Port)), nil
+	if len(a.RawEndpoint) <= 0 {
+		return []byte(fmt.Sprintf("%s:%d", a.IP, a.Port)), nil
+	}
+	return a.RawEndpoint, nil
 }
 
 // UnmarshalText converts a byte array into IPNet. UnmarshalText returns error if invalid CIDR is provided.

--- a/tunnel.go
+++ b/tunnel.go
@@ -136,8 +136,11 @@ func Up(ctx context.Context, config *Config) {
 		ReplacePeers: true,
 		Peers: []wgtypes.PeerConfig{
 			{
-				PublicKey:                   *config.ArcSession.ArcServerPeerPublicKey.AsWgKey(),
-				Endpoint:                    (*net.UDPAddr)(config.ArcSession.ArcServerEndpoint),
+				PublicKey: *config.ArcSession.ArcServerPeerPublicKey.AsWgKey(),
+				Endpoint: &net.UDPAddr{
+					IP:   config.ArcSession.ArcServerEndpoint.IP,
+					Port: config.ArcSession.ArcServerEndpoint.Port,
+				},
 				PersistentKeepaliveInterval: duration(time.Duration(config.PersistentKeepalive) * time.Second),
 				ReplaceAllowedIPs:           true,
 				AllowedIPs:                  allowedIPs,


### PR DESCRIPTION
instead of the pair of "resolved IP address" and "port", because the current implementation cannot handle IPv6 address properly.