### PR TITLE
Show the actual version and revision information through the `version` subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ check: fmt-check test lint vet
 check-ci: fmt-check test vet
 
 $(BIN): $(SRC) go.mod
-	CGO_ENABLED=0 $(GO) build -ldflags="-s -w" -trimpath ./cmd/soratun
+	CGO_ENABLED=0 $(GO) build -ldflags='-s -w -X "github.com/soracom/soratun/internal.Revision=$(shell git rev-parse HEAD)" -X "github.com/soracom/soratun/internal.Version=$(shell git describe --tags $$(git rev-list --tags --max-count=1))"' -trimpath ./cmd/soratun
 
 snapshot: json-schema-docs
 	which goreleaser && goreleaser --snapshot --skip-publish --rm-dist

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,26 +1,26 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/soracom/soratun/internal"
 	"github.com/spf13/cobra"
 )
 
-var (
-	// Commit will be replaced with Git commit for the build.
-	Commit = "tip"
-	// Tag will be replaced with Git tag for the build.
-	Tag = "development"
-)
-
 func versionCmd() *cobra.Command {
+	versionInfo, _ := json.Marshal(map[string]string{
+		"version":  internal.Version,
+		"revision": internal.Revision,
+	})
+
 	return &cobra.Command{
 		Use:     "version",
 		Aliases: []string{"v"},
 		Short:   "Show version",
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("%s (%s)\n", Tag, Commit)
+			fmt.Printf("%s\n", versionInfo)
 		},
 	}
 }

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,0 +1,4 @@
+package internal
+
+var Revision string
+var Version string


### PR DESCRIPTION
e.g.

```
$ ./soratun version
{"revision":"4fa683aa54273b39882a8797edf473f821deb10c","version":"v1.0.0"}
```