### PR TITLE
synchronize versions between go.mod and release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
update go 1.17 for release action

ref. [deps: go 1.17 and update dependencies #20](https://github.com/soracom/soratun/pull/20)