### PR TITLE
add flags to prevent the configuration from persisting on local file system

### DIFF
--- a/bootstrapper_authkey.go
+++ b/bootstrapper_authkey.go
@@ -52,6 +52,8 @@ func (b *AuthKeyBootstrapper) Execute(config *Config) (*Config, error) {
 			EnableMetrics:        true,
 			Interface:            DefaultInterfaceName(),
 			AdditionalAllowedIPs: nil,
+			Mtu:                  DefaultMTU,
+			PersistentKeepalive:  DefaultPersistentKeepaliveInterval,
 			Profile:              b.Profile,
 			ArcSession:           &sim.ArcSession,
 		}

--- a/bootstrapper_cellular.go
+++ b/bootstrapper_cellular.go
@@ -21,6 +21,8 @@ func (b *CellularBootstrapper) Execute(config *Config) (*Config, error) {
 			EnableMetrics:        true,
 			Interface:            DefaultInterfaceName(),
 			AdditionalAllowedIPs: nil,
+			Mtu:                  DefaultMTU,
+			PersistentKeepalive:  DefaultPersistentKeepaliveInterval,
 			Profile:              nil,
 			ArcSession:           nil,
 		}

--- a/bootstrapper_sim_linux.go
+++ b/bootstrapper_sim_linux.go
@@ -35,6 +35,8 @@ func (b *SimBootstrapper) Execute(config *Config) (*Config, error) {
 			EnableMetrics:        true,
 			Interface:            DefaultInterfaceName(),
 			AdditionalAllowedIPs: nil,
+			Mtu:                  DefaultMTU,
+			PersistentKeepalive:  DefaultPersistentKeepaliveInterval,
 			Profile:              nil,
 			ArcSession:           nil,
 		}

--- a/bootstrapper_sim_linux.go
+++ b/bootstrapper_sim_linux.go
@@ -21,7 +21,9 @@ func (b *SimBootstrapper) Execute(config *Config) (*Config, error) {
 		return nil, err
 	}
 
-	fmt.Printf("Running %s %s\n", b.KryptonCliPath, b.Arguments)
+	if v := os.Getenv("SORACOM_VERBOSE"); v != "" {
+		fmt.Fprintf(os.Stderr, "Running %s %s\n", b.KryptonCliPath, b.Arguments)
+	}
 
 	// if no config, create a blank, then replace keys and ArcSession with new
 	if config == nil {
@@ -61,7 +63,10 @@ func (b *SimBootstrapper) Execute(config *Config) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error while marshaling response from krypton-cli: %s", err)
 	}
-	fmt.Printf("Got response from %s: %s\n", b.KryptonCliPath, t)
+
+	if v := os.Getenv("SORACOM_VERBOSE"); v != "" {
+		fmt.Fprintf(os.Stderr, "Got response from %s: %s\n", b.KryptonCliPath, t)
+	}
 
 	config.PrivateKey = arcSession.ArcClientPeerPrivateKey
 	config.PublicKey = (Key)(arcSession.ArcClientPeerPrivateKey.AsWgKey().PublicKey())

--- a/client.go
+++ b/client.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
-	"os"
 	"strings"
 
 	"github.com/soracom/soratun/internal"
@@ -196,10 +195,10 @@ func (c *DefaultSoracomClient) callAPI(params *apiParams) (*http.Response, error
 	}
 
 	if c.Verbose() {
-		fmt.Fprintln(os.Stderr, "--- Request dump ---------------------------------")
+		println("--- Request dump ---------------------------------")
 		r, _ := httputil.DumpRequest(req, true)
-		fmt.Fprintf(os.Stderr, "%s\n", r)
-		fmt.Fprintln(os.Stderr, "--- End of request dump --------------------------")
+		println(r)
+		println("--- End of request dump --------------------------")
 	}
 	res, err := c.doRequest(req)
 	return res, err
@@ -237,10 +236,10 @@ func (c *DefaultSoracomClient) doRequest(req *http.Request) (*http.Response, err
 	}
 
 	if c.Verbose() && res != nil {
-		fmt.Fprintln(os.Stderr, "--- Response dump --------------------------------")
+		println("--- Response dump --------------------------------")
 		r, _ := httputil.DumpResponse(res, true)
-		fmt.Fprintf(os.Stderr, "%s\n", r)
-		fmt.Fprintln(os.Stderr, "--- End of response dump -------------------------")
+		println(r)
+		println("--- End of response dump -------------------------")
 	}
 
 	if res.StatusCode >= http.StatusBadRequest {

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"strings"
 
 	"github.com/soracom/soratun/internal"
@@ -195,10 +196,10 @@ func (c *DefaultSoracomClient) callAPI(params *apiParams) (*http.Response, error
 	}
 
 	if c.Verbose() {
-		println("--- Request dump ---------------------------------")
+		fmt.Fprintln(os.Stderr, "--- Request dump ---------------------------------")
 		r, _ := httputil.DumpRequest(req, true)
-		println(r)
-		println("--- End of request dump --------------------------")
+		fmt.Fprintln(os.Stderr, r)
+		fmt.Fprintln(os.Stderr, "--- End of request dump --------------------------")
 	}
 	res, err := c.doRequest(req)
 	return res, err
@@ -236,10 +237,10 @@ func (c *DefaultSoracomClient) doRequest(req *http.Request) (*http.Response, err
 	}
 
 	if c.Verbose() && res != nil {
-		println("--- Response dump --------------------------------")
+		fmt.Fprintln(os.Stderr, "--- Response dump --------------------------------")
 		r, _ := httputil.DumpResponse(res, true)
-		println(r)
-		println("--- End of response dump -------------------------")
+		fmt.Fprintln(os.Stderr, r)
+		fmt.Fprintln(os.Stderr, "--- End of response dump -------------------------")
 	}
 
 	if res.StatusCode >= http.StatusBadRequest {

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -36,28 +36,28 @@ sim      current SIM             SIM Authentication   Compatible modem/SIM card 
 }
 
 // bootstrap do bootstrap with specified bootstrapper. If persist is set to true, save it to the path specified with "--config" flag
-func bootstrap(bootstrapper soratun.Bootstrapper, persist bool) (*soratun.Config, error) {
+func bootstrap(bootstrapper soratun.Bootstrapper) error {
 	var currentConfig *soratun.Config = nil
 
-	if persist {
+	if !dumpConfig {
 		// if current config exists, pass it to the bootstrapper to merge if applicable
 		currentConfig, _ = readConfig(configPath)
 	}
 
 	config, err := bootstrapper.Execute(currentConfig)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if persist {
-		b, err := json.MarshalIndent(config, "", "  ")
-		if err != nil {
-			return nil, err
-		}
+	b, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
 
+	if !dumpConfig {
 		err = writeConfigurationToFile(string(b))
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		if config.SimId != "" {
@@ -65,9 +65,11 @@ func bootstrap(bootstrapper soratun.Bootstrapper, persist bool) (*soratun.Config
 		}
 
 		printConfigurationFilePath()
+	} else {
+		fmt.Println(string(b))
 	}
 
-	return config, nil
+	return nil
 }
 
 func printConfigurationFilePath() {

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -35,29 +35,37 @@ sim      current SIM             SIM Authentication   Compatible modem/SIM card 
 	return cmd
 }
 
-func bootstrap(bootstrapper soratun.Bootstrapper) (*soratun.Config, error) {
-	// if current config exists, pass it to the bootstrapper to merge if applicable
-	currentConfig, _ := readConfig(configPath)
+// bootstrap do bootstrap with specified bootstrapper. If persist is set to true, save it to the path specified with "--config" flag
+func bootstrap(bootstrapper soratun.Bootstrapper, persist bool) (*soratun.Config, error) {
+	var currentConfig *soratun.Config = nil
+
+	if persist {
+		// if current config exists, pass it to the bootstrapper to merge if applicable
+		currentConfig, _ = readConfig(configPath)
+	}
+
 	config, err := bootstrapper.Execute(currentConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	b, err := json.MarshalIndent(config, "", "  ")
-	if err != nil {
-		return nil, err
-	}
+	if persist {
+		b, err := json.MarshalIndent(config, "", "  ")
+		if err != nil {
+			return nil, err
+		}
 
-	err = writeConfigurationToFile(string(b))
-	if err != nil {
-		return nil, err
-	}
+		err = writeConfigurationToFile(string(b))
+		if err != nil {
+			return nil, err
+		}
 
-	if config.SimId != "" {
-		fmt.Printf("Virtual subscriber SIM ID: %s\n", config.SimId)
-	}
+		if config.SimId != "" {
+			fmt.Printf("Virtual subscriber SIM ID: %s\n", config.SimId)
+		}
 
-	printConfigurationFilePath()
+		printConfigurationFilePath()
+	}
 
 	return config, nil
 }

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -40,7 +40,14 @@ func bootstrap(bootstrapper soratun.Bootstrapper) error {
 	var currentConfig *soratun.Config = nil
 
 	if !dumpConfig {
-		// if current config exists, pass it to the bootstrapper to merge if applicable
+		// Won't check error from `readConfig` because:
+		//
+		// 1. In the very first run, which means no `arc.json` in the file system, the `readConfig` always fail.
+		//    We should move bootstrapping process forward.
+		// 2. Also bootstrap process—creating a new virtual SIM—should be finished successfully regardless of error
+		//    (read failure, invalid JSON format, etc.) Once failed (= `currentCOnfig` is `nil`), Bootstrapper#Execute
+		//    will create a fresh `soratun.Config` (it will vary on each bootstrap method) and can move the process
+		//    forward. Bootstrapper will update existing configuration.
 		currentConfig, _ = readConfig(configPath)
 	}
 

--- a/cmd/bootstrap_authkey.go
+++ b/cmd/bootstrap_authkey.go
@@ -51,9 +51,7 @@ func bootstrapAuthKeyCmd() *cobra.Command {
 				}
 			}
 
-			_, err = bootstrap(&soratun.AuthKeyBootstrapper{
-				Profile: profile,
-			}, true)
+			err = bootstrap(&soratun.AuthKeyBootstrapper{Profile: profile})
 			if err != nil {
 				log.Fatalf("failed to bootstrap: %v", err)
 			}

--- a/cmd/bootstrap_authkey.go
+++ b/cmd/bootstrap_authkey.go
@@ -53,7 +53,7 @@ func bootstrapAuthKeyCmd() *cobra.Command {
 
 			_, err = bootstrap(&soratun.AuthKeyBootstrapper{
 				Profile: profile,
-			})
+			}, true)
 			if err != nil {
 				log.Fatalf("failed to bootstrap: %v", err)
 			}

--- a/cmd/bootstrap_cellular.go
+++ b/cmd/bootstrap_cellular.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/soracom/soratun"
@@ -16,18 +18,29 @@ func bootstrapCellularCmd() *cobra.Command {
 		Long:  "This command will create a new virtual SIM which is associated with current physical SIM, then create configuration for soratun. Need active SORACOM Air for Cellular connection.",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
+			//var err error
 
-			_, err = bootstrap(&soratun.CellularBootstrapper{
+			config, err := bootstrap(&soratun.CellularBootstrapper{
 				Endpoint: kryptonCellularEndpoint,
-			}, true)
+			}, !stdout)
 			if err != nil {
 				log.Fatalf("failed to bootstrap: %v", err)
+			}
+
+			if stdout {
+				b, err := json.MarshalIndent(config, "", "  ")
+				if err != nil {
+					log.Fatalf("failed to decode bootstrapped configuration: %v", err)
+				}
+
+				fmt.Println(string(b))
 			}
 		},
 	}
 
 	cmd.Flags().StringVar(&kryptonCellularEndpoint, "endpoint", "https://krypton.soracom.io:8036", "Specify SORACOM Krypton Provisioning API endpoint.")
+
+	cmd.Flags().BoolVar(&stdout, "stdout", false, "dump configuration to stdout")
 
 	return cmd
 }

--- a/cmd/bootstrap_cellular.go
+++ b/cmd/bootstrap_cellular.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
 	"log"
 
 	"github.com/soracom/soratun"
@@ -18,20 +16,9 @@ func bootstrapCellularCmd() *cobra.Command {
 		Long:  "This command will create a new virtual SIM which is associated with current physical SIM, then create configuration for soratun. Need active SORACOM Air for Cellular connection.",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			config, err := bootstrap(&soratun.CellularBootstrapper{
-				Endpoint: kryptonCellularEndpoint,
-			}, !dumpConfig)
+			err := bootstrap(&soratun.CellularBootstrapper{Endpoint: kryptonCellularEndpoint})
 			if err != nil {
 				log.Fatalf("failed to bootstrap: %v", err)
-			}
-
-			if dumpConfig {
-				b, err := json.MarshalIndent(config, "", "  ")
-				if err != nil {
-					log.Fatalf("failed to decode bootstrapped configuration: %v", err)
-				}
-
-				fmt.Println(string(b))
 			}
 		},
 	}

--- a/cmd/bootstrap_cellular.go
+++ b/cmd/bootstrap_cellular.go
@@ -18,8 +18,6 @@ func bootstrapCellularCmd() *cobra.Command {
 		Long:  "This command will create a new virtual SIM which is associated with current physical SIM, then create configuration for soratun. Need active SORACOM Air for Cellular connection.",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			//var err error
-
 			config, err := bootstrap(&soratun.CellularBootstrapper{
 				Endpoint: kryptonCellularEndpoint,
 			}, !stdout)
@@ -39,8 +37,7 @@ func bootstrapCellularCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&kryptonCellularEndpoint, "endpoint", "https://krypton.soracom.io:8036", "Specify SORACOM Krypton Provisioning API endpoint.")
-
-	cmd.Flags().BoolVar(&stdout, "stdout", false, "dump configuration to stdout")
+	cmd.Flags().BoolVar(&stdout, "stdout", false, "dump configuration to stdout, ignoring --config setting")
 
 	return cmd
 }

--- a/cmd/bootstrap_cellular.go
+++ b/cmd/bootstrap_cellular.go
@@ -20,7 +20,7 @@ func bootstrapCellularCmd() *cobra.Command {
 
 			_, err = bootstrap(&soratun.CellularBootstrapper{
 				Endpoint: kryptonCellularEndpoint,
-			})
+			}, true)
 			if err != nil {
 				log.Fatalf("failed to bootstrap: %v", err)
 			}

--- a/cmd/bootstrap_cellular.go
+++ b/cmd/bootstrap_cellular.go
@@ -20,12 +20,12 @@ func bootstrapCellularCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			config, err := bootstrap(&soratun.CellularBootstrapper{
 				Endpoint: kryptonCellularEndpoint,
-			}, !stdout)
+			}, !dumpConfig)
 			if err != nil {
 				log.Fatalf("failed to bootstrap: %v", err)
 			}
 
-			if stdout {
+			if dumpConfig {
 				b, err := json.MarshalIndent(config, "", "  ")
 				if err != nil {
 					log.Fatalf("failed to decode bootstrapped configuration: %v", err)
@@ -37,7 +37,7 @@ func bootstrapCellularCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&kryptonCellularEndpoint, "endpoint", "https://krypton.soracom.io:8036", "Specify SORACOM Krypton Provisioning API endpoint.")
-	cmd.Flags().BoolVar(&stdout, "stdout", false, "dump configuration to stdout, ignoring --config setting")
+	cmd.Flags().BoolVar(&dumpConfig, "dump-config", false, "dump configuration to stdout, ignoring --config setting")
 
 	return cmd
 }

--- a/cmd/bootstrap_sim.go
+++ b/cmd/bootstrap_sim.go
@@ -66,8 +66,7 @@ func bootstrapSimCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&disableKeyCache, "disable-key-cache", false, "Do not store authentication result to the key cache")
 	cmd.Flags().BoolVar(&clearKeyCache, "clear-key-cache", false, "Remove all items in the key cache")
 	cmd.Flags().StringVar(&kryptonCliPath, "krypton-cli-path", "/usr/local/bin/krypton-cli", "Path to krypton-cli")
-
-	cmd.Flags().BoolVar(&stdout, "stdout", false, "dump configuration to stdout")
+	cmd.Flags().BoolVar(&stdout, "stdout", false, "dump configuration to stdout, ignoring --config setting")
 
 	return cmd
 }

--- a/cmd/bootstrap_sim.go
+++ b/cmd/bootstrap_sim.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -34,21 +33,12 @@ func bootstrapSimCmd() *cobra.Command {
 		Long:  "This command will create a new virtual SIM which is associated with current physical SIM, then create configuration for soratun. You need working \"krypton-cli\". See https://github.com/soracom/krypton-client-go for how to install.",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			config, err := bootstrap(&soratun.SimBootstrapper{
+			err := bootstrap(&soratun.SimBootstrapper{
 				KryptonCliPath: kryptonCliPath,
 				Arguments:      buildKryptonCliArguments(),
-			}, !dumpConfig)
+			})
 			if err != nil {
 				log.Fatalf("failed to bootstrap: %v", err)
-			}
-
-			if dumpConfig {
-				b, err := json.MarshalIndent(config, "", "  ")
-				if err != nil {
-					log.Fatalf("failed to decode bootstrapped configuration: %v", err)
-				}
-
-				fmt.Println(string(b))
 			}
 		},
 	}

--- a/cmd/bootstrap_sim.go
+++ b/cmd/bootstrap_sim.go
@@ -24,7 +24,7 @@ var (
 	disableKeyCache            bool
 	clearKeyCache              bool
 	kryptonCliPath             string
-	stdout                     bool
+	dumpConfig                 bool
 )
 
 func bootstrapSimCmd() *cobra.Command {
@@ -37,12 +37,12 @@ func bootstrapSimCmd() *cobra.Command {
 			config, err := bootstrap(&soratun.SimBootstrapper{
 				KryptonCliPath: kryptonCliPath,
 				Arguments:      buildKryptonCliArguments(),
-			}, !stdout)
+			}, !dumpConfig)
 			if err != nil {
 				log.Fatalf("failed to bootstrap: %v", err)
 			}
 
-			if stdout {
+			if dumpConfig {
 				b, err := json.MarshalIndent(config, "", "  ")
 				if err != nil {
 					log.Fatalf("failed to decode bootstrapped configuration: %v", err)
@@ -66,7 +66,7 @@ func bootstrapSimCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&disableKeyCache, "disable-key-cache", false, "Do not store authentication result to the key cache")
 	cmd.Flags().BoolVar(&clearKeyCache, "clear-key-cache", false, "Remove all items in the key cache")
 	cmd.Flags().StringVar(&kryptonCliPath, "krypton-cli-path", "/usr/local/bin/krypton-cli", "Path to krypton-cli")
-	cmd.Flags().BoolVar(&stdout, "stdout", false, "dump configuration to stdout, ignoring --config setting")
+	cmd.Flags().BoolVar(&dumpConfig, "dump-config", false, "dump configuration to stdout, ignoring --config setting")
 
 	return cmd
 }

--- a/cmd/bootstrap_sim.go
+++ b/cmd/bootstrap_sim.go
@@ -35,7 +35,7 @@ func bootstrapSimCmd() *cobra.Command {
 			_, err := bootstrap(&soratun.SimBootstrapper{
 				KryptonCliPath: kryptonCliPath,
 				Arguments:      buildKryptonCliArguments(),
-			})
+			}, true)
 			if err != nil {
 				log.Fatalf("failed to bootstrap: %v", err)
 			}

--- a/cmd/dump_wireguard_config.go
+++ b/cmd/dump_wireguard_config.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -15,12 +17,12 @@ func dumpWireGuardConfigCmd() *cobra.Command {
 		Args:   cobra.NoArgs,
 		PreRun: initSoratun,
 		Run: func(cmd *cobra.Command, args []string) {
-			dumpWireGuardConfig(false)
+			dumpWireGuardConfig(false, os.Stdout)
 		},
 	}
 }
 
-func dumpWireGuardConfig(mask bool) {
+func dumpWireGuardConfig(mask bool, w io.Writer) {
 	var ips []string
 	for _, ip := range Config.ArcSession.ArcAllowedIPs {
 		ips = append(ips, (*net.IPNet)(ip).String())
@@ -50,7 +52,7 @@ func dumpWireGuardConfig(mask bool) {
 		}
 	}
 
-	fmt.Printf(`[Interface]
+	fmt.Fprintf(w, `[Interface]
 Address = %s/32
 PrivateKey = %s
 MTU = %d

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -51,7 +51,7 @@ func upCmd() *cobra.Command {
 			Config.PersistentKeepalive = persistentKeepalive
 			if additionalAllowedIPs != "" {
 				for _, s := range strings.Split(additionalAllowedIPs, ",") {
-					_, ipnet, err := net.ParseCIDR(s)
+					_, ipnet, err := net.ParseCIDR(strings.TrimSpace(s))
 					if err != nil {
 						log.Fatalf("Invalid CIDR is set for \"--additional-allowd-ips\": %v", err)
 					}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -17,7 +17,7 @@ var (
 	mtu                  int
 	persistentKeepalive  int
 	additionalAllowedIPs string
-	stdin                bool
+	readStdin            bool
 )
 
 func upCmd() *cobra.Command {
@@ -27,7 +27,7 @@ func upCmd() *cobra.Command {
 		Short:   "Setup SORACOM Arc interface",
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			if stdin {
+			if readStdin {
 				b, err := ioutil.ReadAll(os.Stdin)
 				if err != nil {
 					log.Fatalf("Failed to read configuration from stdin: %v", err)
@@ -75,7 +75,7 @@ func upCmd() *cobra.Command {
 	cmd.Flags().IntVar(&mtu, "mtu", soratun.DefaultMTU, "MTU for the interface, which will override arc.json#mtu value")
 	cmd.Flags().IntVar(&persistentKeepalive, "persistent-keepalive", soratun.DefaultPersistentKeepaliveInterval, "WireGuard `PersistentKeepalive` for the SORACOM Arc server, which will override arc.json#persistentKeepalive value")
 	cmd.Flags().StringVar(&additionalAllowedIPs, "additional-allowed-ips", "", "Comma separated string of additional WireGuard allowed CIDRs, which will be added to arc.json#additionalAllowedIPs array")
-	cmd.Flags().BoolVar(&stdin, "stdin", false, "read configuration from stdin, ignoring --config setting")
+	cmd.Flags().BoolVar(&readStdin, "read-stdin", false, "read configuration from stdin, ignoring --config setting")
 
 	return cmd
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -39,9 +39,6 @@ func upCmd() *cobra.Command {
 					log.Fatalf("Failed to read configuration from stdin: %v", err)
 				}
 				Config = &config
-
-				Config.Mtu = mtu
-				Config.PersistentKeepalive = persistentKeepalive
 			} else {
 				initSoratun(cmd, args)
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
@@ -62,9 +63,9 @@ func upCmd() *cobra.Command {
 			}
 
 			if v := os.Getenv("SORACOM_VERBOSE"); v != "" {
-				println("--- WireGuard configuration ----------------------")
+				fmt.Fprintln(os.Stderr, "--- WireGuard configuration ----------------------")
 				dumpWireGuardConfig(true, os.Stderr)
-				println("--- End of WireGuard configuration ---------------")
+				fmt.Fprintln(os.Stderr, "--- End of WireGuard configuration ---------------")
 			}
 
 			soratun.Up(ctx, Config)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -22,9 +21,9 @@ func upCmd() *cobra.Command {
 			}
 
 			if v := os.Getenv("SORACOM_VERBOSE"); v != "" {
-				fmt.Println("--- WireGuard configuration ----------------------")
-				dumpWireGuardConfig(true)
-				fmt.Println("--- End of WireGuard configuration ---------------")
+				println("--- WireGuard configuration ----------------------")
+				dumpWireGuardConfig(true, os.Stderr)
+				println("--- End of WireGuard configuration ---------------")
 			}
 
 			soratun.Up(ctx, Config)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,23 +1,64 @@
 package cmd
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"log"
+	"net"
 	"os"
+	"strings"
 
 	"github.com/soracom/soratun"
 	"github.com/spf13/cobra"
 )
 
+var (
+	mtu                  int
+	persistentKeepalive  int
+	additionalAllowedIPs string
+	stdin                bool
+)
+
 func upCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "up",
 		Aliases: []string{"u"},
 		Short:   "Setup SORACOM Arc interface",
 		Args:    cobra.NoArgs,
-		PreRun:  initSoratun,
 		Run: func(cmd *cobra.Command, args []string) {
+			if stdin {
+				b, err := ioutil.ReadAll(os.Stdin)
+				if err != nil {
+					log.Fatalf("Failed to read configuration from stdin: %v", err)
+				}
+
+				var config soratun.Config
+				err = json.Unmarshal(b, &config)
+				if err != nil {
+					log.Fatalf("Failed to read configuration from stdin: %v", err)
+				}
+				Config = &config
+			} else {
+				initSoratun(cmd, args)
+			}
+
 			if Config.ArcSession == nil {
 				log.Fatal("Failed to determine connection information. Please bootstrap or create a new session from the user console.")
+			}
+
+			Config.Mtu = mtu
+			Config.PersistentKeepalive = persistentKeepalive
+			if additionalAllowedIPs != "" {
+				for _, s := range strings.Split(additionalAllowedIPs, ",") {
+					_, ipnet, err := net.ParseCIDR(s)
+					if err != nil {
+						log.Fatalf("Invalid CIDR is set for \"--additional-allowd-ips\": %v", err)
+					}
+					Config.ArcSession.ArcAllowedIPs = append(Config.ArcSession.ArcAllowedIPs, &soratun.IPNet{
+						IP:   ipnet.IP,
+						Mask: ipnet.Mask,
+					})
+				}
 			}
 
 			if v := os.Getenv("SORACOM_VERBOSE"); v != "" {
@@ -29,4 +70,11 @@ func upCmd() *cobra.Command {
 			soratun.Up(ctx, Config)
 		},
 	}
+
+	cmd.Flags().IntVar(&mtu, "mtu", soratun.DefaultMTU, "MTU for the interface, which will override arc.json#mtu value")
+	cmd.Flags().IntVar(&persistentKeepalive, "persistent-keepalive", soratun.DefaultPersistentKeepaliveInterval, "WireGuard `PersistentKeepalive` for the SORACOM Arc server, which will override arc.json#persistentKeepalive value")
+	cmd.Flags().StringVar(&additionalAllowedIPs, "additional-allowed-ips", "", "Comma separated string of additional WireGuard allowed CIDRs, which will be added to arc.json#additionalAllowedIPs array")
+	cmd.Flags().BoolVar(&stdin, "stdin", false, "read configuration from stdin, ignoring --config setting")
+
+	return cmd
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -41,15 +41,15 @@ func upCmd() *cobra.Command {
 				Config = &config
 			} else {
 				initSoratun(cmd, args)
+			}
 
-				// override only if the flag was explicitly set
-				if cmd.Flags().Changed("mtu") {
-					Config.Mtu = mtu
-				}
+			// override only if the flag was explicitly set
+			if cmd.Flags().Changed("mtu") {
+				Config.Mtu = mtu
+			}
 
-				if cmd.Flags().Changed("persistent-keepalive") {
-					Config.PersistentKeepalive = persistentKeepalive
-				}
+			if cmd.Flags().Changed("persistent-keepalive") {
+				Config.PersistentKeepalive = persistentKeepalive
 			}
 
 			if Config.ArcSession == nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -39,16 +39,26 @@ func upCmd() *cobra.Command {
 					log.Fatalf("Failed to read configuration from stdin: %v", err)
 				}
 				Config = &config
+
+				Config.Mtu = mtu
+				Config.PersistentKeepalive = persistentKeepalive
 			} else {
 				initSoratun(cmd, args)
+
+				// override only if the flag was explicitly set
+				if cmd.Flags().Changed("mtu") {
+					Config.Mtu = mtu
+				}
+
+				if cmd.Flags().Changed("persistent-keepalive") {
+					Config.PersistentKeepalive = persistentKeepalive
+				}
 			}
 
 			if Config.ArcSession == nil {
 				log.Fatal("Failed to determine connection information. Please bootstrap or create a new session from the user console.")
 			}
 
-			Config.Mtu = mtu
-			Config.PersistentKeepalive = persistentKeepalive
 			if additionalAllowedIPs != "" {
 				for _, s := range strings.Split(additionalAllowedIPs, ",") {
 					_, ipnet, err := net.ParseCIDR(strings.TrimSpace(s))

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	SimId string `json:"simId"`
 	// LogLevel specifies logging level, verbose, error, or silent.
 	LogLevel int `json:"logLevel"`
-	// If EnableMetrics is true, metrics will be logged when log-level is verbose or error.
+	// If EnableMetrics is true, metrics will be logged when log-level is verbose.
 	EnableMetrics bool `json:"enableMetrics"`
 	// Interface is name for the tunnel interface.
 	Interface string `json:"interface"`

--- a/krypton_client.go
+++ b/krypton_client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"strings"
 
 	"github.com/soracom/soratun/internal"
@@ -93,10 +94,10 @@ func (c *DefaultSoracomKryptonClient) callAPI(params *apiParams) (*http.Response
 	}
 
 	if c.Verbose() {
-		println("--- Request dump ---------------------------------")
+		fmt.Fprintln(os.Stderr, "--- Request dump ---------------------------------")
 		r, _ := httputil.DumpRequest(req, true)
-		println(r)
-		println("--- End of request dump --------------------------")
+		fmt.Fprintln(os.Stderr, r)
+		fmt.Fprintln(os.Stderr, "--- End of request dump --------------------------")
 	}
 	res, err := c.doRequest(req)
 	return res, err
@@ -128,10 +129,10 @@ func (c *DefaultSoracomKryptonClient) doRequest(req *http.Request) (*http.Respon
 	}
 
 	if c.Verbose() && res != nil {
-		println("--- Response dump --------------------------------")
+		fmt.Fprintln(os.Stderr, "--- Response dump --------------------------------")
 		r, _ := httputil.DumpResponse(res, true)
-		println(r)
-		println("--- End of response dump -------------------------")
+		fmt.Fprintln(os.Stderr, r)
+		fmt.Fprintln(os.Stderr, "--- End of response dump -------------------------")
 	}
 
 	if res.StatusCode >= http.StatusBadRequest {

--- a/krypton_client.go
+++ b/krypton_client.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
-	"os"
 	"strings"
 
 	"github.com/soracom/soratun/internal"
@@ -94,10 +93,10 @@ func (c *DefaultSoracomKryptonClient) callAPI(params *apiParams) (*http.Response
 	}
 
 	if c.Verbose() {
-		fmt.Fprintln(os.Stderr, "--- Request dump ---------------------------------")
+		println("--- Request dump ---------------------------------")
 		r, _ := httputil.DumpRequest(req, true)
-		fmt.Fprintf(os.Stderr, "%s\n", r)
-		fmt.Fprintln(os.Stderr, "--- End of request dump --------------------------")
+		println(r)
+		println("--- End of request dump --------------------------")
 	}
 	res, err := c.doRequest(req)
 	return res, err
@@ -129,10 +128,10 @@ func (c *DefaultSoracomKryptonClient) doRequest(req *http.Request) (*http.Respon
 	}
 
 	if c.Verbose() && res != nil {
-		fmt.Fprintln(os.Stderr, "--- Response dump --------------------------------")
+		println("--- Response dump --------------------------------")
 		r, _ := httputil.DumpResponse(res, true)
-		fmt.Fprintf(os.Stderr, "%s\n", r)
-		fmt.Fprintln(os.Stderr, "--- End of response dump -------------------------")
+		println(r)
+		println("--- End of response dump -------------------------")
 	}
 
 	if res.StatusCode >= http.StatusBadRequest {


### PR DESCRIPTION
For some use cases, saving WireGuard private key in plain text file will be a security concern, although kernel-native WireGuard does. File system encryption and setting proper permission could mitigate the concern, but this PR will add another way to improve the situation. In short:

```
$ ./soratun boostrap <cellular|sim> --dump-config | sudo ./soratun up --read-stdin
```

1. `bootstrap <cellular|sim> --dump-config` flag will bootstrap the virtual SIM, then output configuration (`arc.json` equivalent) to stdout,
   - Since `sim` and `cellular` based bootstrap is idemponent, we can repeatedly do that. Every bootstrap will return same virtual SIM, with new pair of WireGuard key etc.
   - On the other hand, `authkey` based bootstrap will create new virtual SIM every time when it's called, if `arc.json` does not exist. This means additional costs. Hence it does not make sense to support this way for `authkey`.
2. `up --read-stdin` flag specifies reading the configuration from stdin, then connect to the SORACOM platform

The changes will prevent the configuration from persisting on local file system.

Some notes:

- Platform native tools and APIs e.g. macOS Keychain is a good way to store such secrets, but will introduce additional complexity.
- `--config` flag will be ignored if `--dump-config` and `--read-stdin` are specified. As a start point, `additionalAllowedIPs`, `mtu`, and `persistentKeepalive` can be specified via respective flags. I may add others e.g. `interface`, `logLevel`, etc. based on future feature requests. (it might needs some internal refactoring.)
- The tag should be `v1.2.0` once merged.
