### PR TITLE
security: mask sensitive information

### DIFF
--- a/bootstrapper_sim_linux.go
+++ b/bootstrapper_sim_linux.go
@@ -49,13 +49,17 @@ func (b *SimBootstrapper) Execute(config *Config) (*Config, error) {
 		log.Fatalf("Error while running %s: %s\n%s", b.KryptonCliPath, err, &stderr)
 	}
 
-	fmt.Printf("Got response from %s: %s\n", b.KryptonCliPath, stdout.String())
-
 	var arcSession ArcSession
 	err = json.Unmarshal(stdout.Bytes(), &arcSession)
 	if err != nil {
 		return nil, fmt.Errorf("error while reading response from krypton-cli: %s\nkrypton-cli output:\n-----\n%s", err, stdout.String())
 	}
+
+	t, err := json.Marshal(&arcSession)
+	if err != nil {
+		return nil, fmt.Errorf("error while marshaling response from krypton-cli: %s", err)
+	}
+	fmt.Printf("Got response from %s: %s\n", b.KryptonCliPath, t)
 
 	config.PrivateKey = arcSession.ArcClientPeerPrivateKey
 	config.PublicKey = (Key)(arcSession.ArcClientPeerPrivateKey.AsWgKey().PublicKey())

--- a/bootstrapper_sim_linux.go
+++ b/bootstrapper_sim_linux.go
@@ -55,6 +55,8 @@ func (b *SimBootstrapper) Execute(config *Config) (*Config, error) {
 		return nil, fmt.Errorf("error while reading response from krypton-cli: %s\nkrypton-cli output:\n-----\n%s", err, stdout.String())
 	}
 
+	// Since soratun.ArcSession marshaler omits ArcClientPeerPrivateKey, we can simply and safely marshal response from
+	// Krypton CLI, and print it to stdout.
 	t, err := json.Marshal(&arcSession)
 	if err != nil {
 		return nil, fmt.Errorf("error while marshaling response from krypton-cli: %s", err)

--- a/client.go
+++ b/client.go
@@ -79,12 +79,12 @@ type SimProfile struct {
 func NewDefaultSoracomClient(p Profile) (SoracomClient, error) {
 	authKeyId := p.AuthKeyID
 	if authKeyId == "" || !strings.HasPrefix(authKeyId, "keyId-") {
-		return nil, fmt.Errorf("invalid AuthKeyId \"%s\". It must starts with \"keyId-\"", authKeyId)
+		return nil, fmt.Errorf("invalid AuthKeyId is provided. It must starts with \"keyId-\"")
 	}
 
 	authKey := p.AuthKey
 	if authKey == "" || !strings.HasPrefix(authKey, "secret-") {
-		return nil, fmt.Errorf("invalid AuthKey \"%s\". It must starts with \"secret-\"", authKey)
+		return nil, fmt.Errorf("invalid AuthKey is provided. It must starts with \"secret-\"")
 	}
 
 	endpoint := p.Endpoint

--- a/cmd/dump_wireguard_config.go
+++ b/cmd/dump_wireguard_config.go
@@ -15,15 +15,20 @@ func dumpWireGuardConfigCmd() *cobra.Command {
 		Args:   cobra.NoArgs,
 		PreRun: initSoratun,
 		Run: func(cmd *cobra.Command, args []string) {
-			dumpWireGuardConfig()
+			dumpWireGuardConfig(false)
 		},
 	}
 }
 
-func dumpWireGuardConfig() {
+func dumpWireGuardConfig(mask bool) {
 	var ips []string
 	for _, ip := range Config.ArcSession.ArcAllowedIPs {
 		ips = append(ips, (*net.IPNet)(ip).String())
+	}
+
+	privateKey := (Config.PrivateKey).String()
+	if mask {
+		privateKey = "(hidden)"
 	}
 
 	postUp := ""
@@ -57,7 +62,7 @@ Endpoint = %s:%d
 PersistentKeepalive = %d
 `,
 		Config.ArcSession.ArcClientPeerIpAddress,
-		Config.PrivateKey,
+		privateKey,
 		Config.Mtu,
 		postUp,
 		postDown,

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -62,7 +62,6 @@ func printDevice(d *wgtypes.Device) {
 		d.Name,
 		d.Type.String(),
 		d.PublicKey.String(),
-		//d.PrivateKey.String(),
 		d.ListenPort)
 }
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -23,7 +23,7 @@ func upCmd() *cobra.Command {
 
 			if v := os.Getenv("SORACOM_VERBOSE"); v != "" {
 				fmt.Println("--- WireGuard configuration ----------------------")
-				dumpWireGuardConfig()
+				dumpWireGuardConfig(true)
 				fmt.Println("--- End of WireGuard configuration ---------------")
 			}
 

--- a/tunnel.go
+++ b/tunnel.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 // Package soratun implements userspace SORACOM Arc client.
 package soratun


### PR DESCRIPTION
- security: strip private key from krypton cli response
- security: don't log AuthKeyId and AuthKey while getting error
- security: don't print private key as debug information
- chore: update build tag for go 1.17
