### PR TITLE
Correct the value type of the `--persistent-keepalive`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,5 +20,4 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.40
-
+        version: v1.49

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ import (
 // A SoracomClient represents an API client for SORACOM API. See
 // https://developers.soracom.io/en/docs/tools/api-reference/ or
 // https://dev.soracom.io/jp/docs/api_guide/
+//
 //go:generate mockgen -source client.go -destination internal/mock/client.go
 type SoracomClient interface {
 	CreateVirtualSim() (*VirtualSim, error)

--- a/client.go
+++ b/client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -251,7 +250,7 @@ func (c *DefaultSoracomClient) doRequest(req *http.Request) (*http.Response, err
 				fmt.Println("failed to close response", err)
 			}
 		}()
-		r, _ := ioutil.ReadAll(res.Body)
+		r, _ := io.ReadAll(res.Body)
 		return res, fmt.Errorf("%s: %s %s: %s", res.Status, req.Method, req.URL, r)
 	}
 	return res, nil

--- a/cmd/bootstrap_authkey.go
+++ b/cmd/bootstrap_authkey.go
@@ -60,7 +60,7 @@ func bootstrapAuthKeyCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&authKeyId, "auth-key-id", "", "SORACOM API auth key ID")
 	cmd.Flags().StringVar(&authKey, "auth-key", "", "SORACOM API auth key")
-	cmd.Flags().StringVar(&coverage, "coverage-type", "", "Specify coverage type, 'g' for Global, 'jp' for Japan")
+	cmd.Flags().StringVar(&coverage, "coverage-type", "", "Specify coverage type, \"g\" for Global, \"jp\" for Japan")
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -67,7 +66,7 @@ func initSoratun(_ *cobra.Command, _ []string) {
 }
 
 func readConfig(path string) (*soratun.Config, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open config file: %s", path)
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -80,7 +80,7 @@ func upCmd() *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&mtu, "mtu", soratun.DefaultMTU, "MTU for the interface, which will override arc.json#mtu value")
-	cmd.Flags().IntVar(&persistentKeepalive, "persistent-keepalive", soratun.DefaultPersistentKeepaliveInterval, "WireGuard `PersistentKeepalive` for the SORACOM Arc server, which will override arc.json#persistentKeepalive value")
+	cmd.Flags().IntVar(&persistentKeepalive, "persistent-keepalive", soratun.DefaultPersistentKeepaliveInterval, "WireGuard \"PersistentKeepalive\" for the SORACOM Arc server, which will override arc.json#persistentKeepalive value")
 	cmd.Flags().StringVar(&additionalAllowedIPs, "additional-allowed-ips", "", "Comma separated string of additional WireGuard allowed CIDRs, which will be added to arc.json#additionalAllowedIPs array")
 	cmd.Flags().BoolVar(&readStdin, "read-stdin", false, "read configuration from stdin, ignoring --config setting")
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -28,7 +28,7 @@ func upCmd() *cobra.Command {
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			if readStdin {
-				b, err := ioutil.ReadAll(os.Stdin)
+				b, err := io.ReadAll(os.Stdin)
 				if err != nil {
 					log.Fatalf("Failed to read configuration from stdin: %v", err)
 				}

--- a/krypton_client.go
+++ b/krypton_client.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -142,7 +141,7 @@ func (c *DefaultSoracomKryptonClient) doRequest(req *http.Request) (*http.Respon
 				fmt.Println("failed to close response", err)
 			}
 		}()
-		r, _ := ioutil.ReadAll(res.Body)
+		r, _ := io.ReadAll(res.Body)
 		return res, fmt.Errorf("%s: %s %s: %s", res.Status, req.Method, req.URL, r)
 	}
 	return res, nil


### PR DESCRIPTION
### TL;DR

`s/PersistentKeepalive/int/`

---

Previous:

```
      --persistent-keepalive PersistentKeepalive   WireGuard PersistentKeepalive for the SORACOM Arc server, which will override arc.json#persistentKeepalive value (default 60)
```

Corrected:

```
      --persistent-keepalive int        WireGuard "PersistentKeepalive" for the SORACOM Arc server, which will override arc.json#persistentKeepalive value (default 60)
```

This is because of the `pflag` package trick; that package extracts the back-quoted word from the usage text and guesses/uses that word as the type of value.
ref: https://github.com/spf13/pflag/issues/200

This might come from the original golang's flag package:

> ...
> can be changed by placing a back-quoted name in the flag's usage string; the first such item in the message is taken to be a parameter name to show in the message and the back quotes are stripped from the message when displayed
> https://pkg.go.dev/flag#PrintDefaults

So this patch replaces the back-quotes with double-quotes to avoid the unexpected behavior.