### PR TITLE
fix: revert actions/checkout to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
       -


### PR DESCRIPTION
As you can see the error at https://github.com/soracom/soratun/actions/runs/4975810290, there is no [actions/checkout](https://github.com/actions/checkout) v4... I'm not sure why I did this, but overlooked until tagging [v1.2.2](https://github.com/soracom/soratun/releases/tag/v1.2.2). This PR reverted the action version.

```
goreleaser
Unable to resolve action `actions/checkout@v4`, unable to find version `v4`
```

I'll create a new tag v1.2.3 after merge.