### PR TITLE
fix: quote setup-go/go-version specification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: '1.20'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
Sorry for multiple release failures. Due to previous notation, setup-go will download go 1.2.2, and it resulted in following error on release.

```
failed: go mod download: exit status 2; output: go: unknown subcommand "mod"
```
