### PR TITLE
build: goreleaser v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: '1.21'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --rm-dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: soratun
 before:
   hooks:
@@ -27,7 +28,7 @@ builds:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 release:
   draft: true
 archives:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_VERSION=1.61.0
 GOIMPORTS_VERSION=0.12.0
 MOCKGEN_VERSION=0.2.0
 JSON_SCHEMA_DOCS_VERSION=0.2.1
-GORELEASER_VERSION=1.20.0
+GORELEASER_VERSION=2.3.2
 
 check: fmt-check test lint vet
 check-ci: fmt-check test vet
@@ -17,7 +17,7 @@ $(BIN): $(SRC) go.mod
 	CGO_ENABLED=0 $(GO) build -ldflags='-s -w -X "github.com/soracom/soratun/internal.Revision=$(shell git rev-parse HEAD)" -X "github.com/soracom/soratun/internal.Version=$(shell git describe --tags $$(git rev-list --tags --max-count=1))"' -trimpath ./cmd/soratun
 
 snapshot: json-schema-docs
-	which goreleaser && goreleaser --snapshot --skip-publish --clean
+	which goreleaser && goreleaser --snapshot --skip=publish --clean
 
 clean:
 	rm -fr $(BIN) dist
@@ -63,7 +63,7 @@ install-dev-deps:
 		&& go install golang.org/x/tools/cmd/goimports@v$(GOIMPORTS_VERSION) \
 		&& go install go.uber.org/mock/mockgen@v$(MOCKGEN_VERSION) \
 		&& go install github.com/marcusolsson/json-schema-docs@v$(JSON_SCHEMA_DOCS_VERSION) \
-		&& go install github.com/goreleaser/goreleaser@v$(GORELEASER_VERSION)
+		&& go install github.com/goreleaser/goreleaser/v2@v$(GORELEASER_VERSION)
 
 lint:
 	golangci-lint run ./...


### PR DESCRIPTION
- update development dependency
  - goreleaser v2.3.2
- update GitHub Actions
  - goreleaser/goreleaser-action v6 (#71)

No new release (git tag) will be created after merging this PR, as it doesn't introduce any functional changes.
