### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 #
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
-* kaoru@soracom.jp
+* @soracom/air


### PR DESCRIPTION
As we discussed in the internal meeting, this PR will update the CODEOWNERS file to include the `soracom/air` group. Since I'm currently the only owner of the repo, I've added @malikolivier as a reviewer because at least one approval is required to merge.