### PR TITLE
fix: update GoReleaser workflow for v2 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: '1.23'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist
+          version: v2
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

When attempting to create a release by pushing a git tag, the GoReleaser GitHub Action workflow failed with the following error:

```
⨯ command failed error=unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.12.7/x64/goreleaser' failed with exit code 1
```

This error occurred because the `--rm-dist` flag was deprecated and removed in GoReleaser v2. The workflow was using `version: latest` which automatically upgraded to v2.12.7, but the configuration still used the old v1 flag syntax.

## Solution

This PR updates the `.github/workflows/release.yml` to be compatible with GoReleaser v2:

### Changes Made

1. **Updated GoReleaser flag**: Changed `--rm-dist` to `--clean` (new v2 syntax)
2. **Pinned GoReleaser version**: Changed from `version: latest` to `version: v2` to avoid unexpected breaking changes
3. **Updated Go version**: Changed from `1.21` to `1.23` to match the version specified in `go.mod` (1.23.1)

### Verification

The `.goreleaser.yml` configuration file was verified to be fully compatible with GoReleaser v2:
- Already uses `version: 2` header
- Uses correct plural forms (`builds`, `archives`)
- Does not use any deprecated fields that were removed in v2

## References

- [GoReleaser v2 Announcement](https://goreleaser.com/blog/goreleaser-v2/)
- [GoReleaser Deprecation Notices](https://goreleaser.com/deprecations/)